### PR TITLE
Update script tag typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Via `script` tag:
 <script src="https://unpkg.com/netlify-cms-widget-async-select@^1.0.0"></script>
 
 <script>
-  CMS.registerWidget('async-select', window.asyncSelectControl, window.asyncSelectPreview)
+  CMS.registerWidget('async-select', window.AsyncSelectControl, window.AsyncSelectPreview)
 </script>
 ```
 


### PR DESCRIPTION
Couldn't figure out why this wasn't working until I noticed what was actually being exported: https://github.com/chrisboustead/netlify-cms-widget-async-select/blob/master/src/index.js#L5-L6

Thanks for putting this widget together - surprised this functionality isn't built into the Netlify version.